### PR TITLE
Fix typos in lost luggage

### DIFF
--- a/lost_luggage_distribution/lost_luggage_distribution.ipynb
+++ b/lost_luggage_distribution/lost_luggage_distribution.ipynb
@@ -86,10 +86,10 @@
     "\\sum_{k \\in V}  y_{i,k} = 1 \\quad \\forall i \\in L \\setminus \\{0\\}\n",
     "\\end{equation}\n",
     "\n",
-    "**Depot**: Heathrow is visited by every van used. \n",
+    "**Depot**: Heathrow is visited by every van used. (Note: to improve performance, we diverge from the book by disaggregating this constraint).\n",
     "\n",
     "\\begin{equation}\n",
-    "\\sum_{k \\in V}  y_{1,k} \\geq \\sum_{k \\in V} z_k\n",
+    "y_{0,k} = z_k \\quad \\forall k \\in V\n",
     "\\end{equation}\n",
     "\n",
     "**Arriving at a location**: If location $j$ is visited by van $k$, then the van is coming from another location $i$.\n",
@@ -284,7 +284,7 @@
    "outputs": [],
    "source": [
     "# Depot constraint\n",
-    "depotConstr = m.addConstr(y.sum(0,'*') >= z.sum(), name='depotConstr' )"
+    "depotConstr = m.addConstrs((y[0, k] == z[k] for k in vans), name='depotConstr' )"
    ]
   },
   {

--- a/lost_luggage_distribution/lost_luggage_distribution_gcl.ipynb
+++ b/lost_luggage_distribution/lost_luggage_distribution_gcl.ipynb
@@ -83,10 +83,10 @@
     "\\sum_{k \\in V}  y_{i,k} = 1 \\quad \\forall i \\in L \\setminus \\{0\\}\n",
     "\\end{equation}\n",
     "\n",
-    "**Depot**: Heathrow is visited by every van used. \n",
+    "**Depot**: Heathrow is visited by every van used. (Note: to improve performance, we diverge from the book by disaggregating this constraint).\n",
     "\n",
     "\\begin{equation}\n",
-    "\\sum_{k \\in V}  y_{1,k} \\geq \\sum_{k \\in V} z_k\n",
+    "y_{0,k} = z_k \\quad \\forall k \\in V\n",
     "\\end{equation}\n",
     "\n",
     "**Arriving at a location**: If location $j$ is visited by van $k$, then the van is coming from another location $i$.\n",
@@ -290,7 +290,7 @@
    "outputs": [],
    "source": [
     "# Depot constraint\n",
-    "depotConstr = m.addConstr(y.sum(0,'*') >= z.sum(), name='depotConstr' )"
+    "depotConstr = m.addConstrs((y[0, k] == z[k] for k in vans), name='depotConstr' )"
    ]
   },
   {
@@ -388,7 +388,7 @@
    "metadata": {},
    "source": [
     "### Callback Definition\n",
-    "Subtour constraints prevent a van from visiting a set of destinations without starting or ending at the Heathrow depot. Because there are an exponential number of these constraints, we don't want to add them all to the model. Instead, we use a callback function to find violated subtour constraints and add them to the model as lazy constraints:"
+    "Subtour constraints prevent a van from visiting a set of destinations without starting or ending at the Heathrow depot. Because there are an exponential number of these constraints, we don't want to add them all to the model. Instead, we use a callback function to find violated subtour constraints and add them to the model as lazy constraints."
    ]
   },
   {


### PR DESCRIPTION
Fix typos in writeup for lost luggage; disaggregating one set of constraints to make it more clear.