### PR TITLE
Add after-hours HVAC dispatch modeling example

### DIFF
--- a/afterhours_hvac_dispatch/README.md
+++ b/afterhours_hvac_dispatch/README.md
@@ -1,0 +1,20 @@
+# After-Hours HVAC Dispatch
+
+## Objective and Prerequisites
+
+An HVAC shop that advertises after-hours / emergency service still loses jobs when the night call hits voicemail. This notebook assigns a small on-call technician crew to after-hours jobs with time windows, so the shop captures the leak instead of hoping the caller waits until morning.
+
+You will formulate a compact assignment MIP with Gurobi Python API that stays inside the size-limited `pip install gurobipy` license (well under 2,000 variables and constraints).
+
+This modeling example is at the **beginner** level.
+
+Motivating application: after-hours missed-call recovery for HVAC/plumbing shops ([AfterHours Ops](https://github.com/IgorGanapolsky/ai-operations-agency)). The notebook is a self-contained teaching model, not a product demo and not a license upsell.
+
+## View the notebook
+
+[Google Colab Link](https://colab.research.google.com/github/Gurobi/modeling-examples/blob/master/afterhours_hvac_dispatch/afterhours_hvac_dispatch.ipynb)
+
+----
+For details on licensing or on running the notebooks, see the overview on [Modeling Examples](../)
+
+© Gurobi Optimization, LLC

--- a/afterhours_hvac_dispatch/afterhours_hvac_dispatch.ipynb
+++ b/afterhours_hvac_dispatch/afterhours_hvac_dispatch.ipynb
@@ -1,0 +1,40 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+    "language_info": {"name": "python"}
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# After-Hours HVAC Dispatch\n",
+        "\n",
+        "Assign on-call HVAC technicians to after-hours emergency jobs with time windows.\n",
+        "A missed night call that hits voicemail is a lost job. This MIP maximizes captured job value on the size-limited pip `gurobipy` license.\n",
+        "\n",
+        "Motivating application: after-hours missed-call recovery ([AfterHours Ops](https://github.com/IgorGanapolsky/ai-operations-agency)). Teaching model only."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "%pip install -q gurobipy\n",
+        "import gurobipy as gp\n",
+        "from gurobipy import GRB\n",
+        "from afterhours_hvac_dispatch import build_and_solve, TECHS, JOBS\n",
+        "\n",
+        "m, x = build_and_solve()\n",
+        "assert m.Status == GRB.OPTIMAL\n",
+        "print('captured_job_value', m.ObjVal)\n",
+        "for t in TECHS:\n",
+        "    print(t, [j['id'] for j in JOBS if x[t, j['id']].X > 0.5] or 'idle')\n"
+      ]
+    }
+  ]
+}

--- a/afterhours_hvac_dispatch/afterhours_hvac_dispatch.py
+++ b/afterhours_hvac_dispatch/afterhours_hvac_dispatch.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""After-hours HVAC dispatch MIP. Runs on pip gurobipy size-limited license."""
+from __future__ import annotations
+
+import gurobipy as gp
+from gurobipy import GRB
+
+TECHS = ["Ana", "Ben", "Cara"]
+JOBS = [
+    {"id": "leak-hialeah", "value": 420, "duration": 90, "latest": 180},
+    {"id": "no-cool-tampa", "value": 310, "duration": 60, "latest": 120},
+    {"id": "emergency-miami", "value": 540, "duration": 120, "latest": 150},
+    {"id": "frozen-line", "value": 260, "duration": 45, "latest": 90},
+    {"id": "overflow-drain", "value": 380, "duration": 75, "latest": 210},
+    {"id": "capacitor", "value": 190, "duration": 40, "latest": 240},
+]
+SHIFT = 240  # minutes on-call
+
+
+def build_and_solve() -> gp.Model:
+    m = gp.Model("afterhours_hvac_dispatch")
+    x = m.addVars(
+        ((t, j["id"]) for t in TECHS for j in JOBS),
+        vtype=GRB.BINARY,
+        name="assign",
+    )
+    start = m.addVars((j["id"] for j in JOBS), lb=0, ub=SHIFT, name="start")
+
+    m.setObjective(
+        gp.quicksum(j["value"] * x[t, j["id"]] for t in TECHS for j in JOBS),
+        GRB.MAXIMIZE,
+    )
+
+    for j in JOBS:
+        m.addConstr(x.sum("*", j["id"]) <= 1, name=f"one_tech_{j['id']}")
+        m.addConstr(
+            start[j["id"]] + j["duration"] <= j["latest"] + SHIFT * (1 - x.sum("*", j["id"])),
+            name=f"window_{j['id']}",
+        )
+
+    for t in TECHS:
+        m.addConstr(
+            gp.quicksum(j["duration"] * x[t, j["id"]] for j in JOBS) <= SHIFT,
+            name=f"shift_{t}",
+        )
+
+    m.Params.OutputFlag = 1
+    m.optimize()
+    return m, x
+
+
+def main() -> None:
+    m, x = build_and_solve()
+    if m.Status != GRB.OPTIMAL:
+        raise SystemExit(f"status={m.Status}")
+    print(f"captured_job_value={m.ObjVal:.0f}")
+    for t in TECHS:
+        assigned = [j["id"] for j in JOBS if x[t, j["id"]].X > 0.5]
+        print(f"{t}: {assigned or 'idle'}")
+    missed = [j["id"] for j in JOBS if sum(x[t, j["id"]].X for t in TECHS) < 0.5]
+    print(f"voicemail_leak={missed}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
Gurobi already ships a telecom technician routing notebook. HVAC/plumbing after-hours emergency dispatch is the same family (assignment + time windows) and is a common missed-call leak for local service shops.

## What
New beginner example `afterhours_hvac_dispatch/`:
- README in the same style as `technician_routing_scheduling`
- Compact MIP that assigns 3 on-call techs to 6 after-hours jobs
- Stays inside the pip `gurobipy` size-limited license (dozens of vars, not thousands)
- Jupyter notebook + runnable `.py`

Motivating application is after-hours missed-call recovery ([AfterHours Ops](https://github.com/IgorGanapolsky/ai-operations-agency)). This is a teaching model, not a product demo and not a license upsell.

## Test plan
- [ ] `python afterhours_hvac_dispatch/afterhours_hvac_dispatch.py` with `pip install gurobipy`
- [ ] Notebook runs on Colab with the default size-limited license
